### PR TITLE
fix(mergeDeep): do not merge __proto__ property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utilitify",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "The utilities for working with a collections such as objects, arrays and primitives such as numbers, strings, etc.",
   "main": "index.js",
   "repository": "https://github.com/xcritical-software/utilitify.git",

--- a/src/__tests__/mergeDeep.test.ts
+++ b/src/__tests__/mergeDeep.test.ts
@@ -1,7 +1,24 @@
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
 import { mergeDeep } from '../utils';
 
 
 describe('This is the tests for the "merge deep" util', () => {
+  test('should not merge the __proto__ property', () => {
+    const src = JSON.parse('{ "__proto__": { "xxx": "polluted" } }');
+    const dst = {};
+
+    mergeDeep(dst, src);
+    // @ts-ignore
+    if (typeof dst.__proto__ !== 'undefined') { // eslint-disable-line
+      // Should not overwrite the __proto__ property or pollute the Object prototype
+      // @ts-ignore
+      expect(dst.__proto__).toBe(Object.prototype); // eslint-disable-line
+    }
+
+    // @ts-ignore
+    expect(({}).xxx).toBeUndefined();
+  });
+
   test('Merge two objects', () => {
     expect(mergeDeep({ a: 1, b: 2 }, { b: 3, c: 4 })).toEqual({ a: 1, b: 3, c: 4 });
 

--- a/src/utils/mergeDeep.ts
+++ b/src/utils/mergeDeep.ts
@@ -4,17 +4,20 @@ import { isObject } from './isObject';
 import { AllType } from '../interfaces';
 
 
+const checkValidKeys = (key: string): boolean => key !== '__proto__' && key !== 'constructor' && key !== 'prototype';
+
 const merge = (target: AllType, obj: AllType): AllType => {
   Object.keys(obj).forEach((key: string): void => {
-    const oldVal = obj[key];
-    const newVal = target[key];
-
-    if (isObject(newVal) && isObject(oldVal)) {
-      target[key] = merge(newVal, oldVal);
-    } else if (Array.isArray(newVal)) {
-      target[key] = union([], newVal, oldVal);
-    } else {
-      target[key] = cloneDeep(oldVal);
+    if (checkValidKeys(key)) {
+      const oldVal = obj[key];
+      const newVal = target[key];
+      if (isObject(newVal) && isObject(oldVal)) {
+        target[key] = merge(newVal, oldVal);
+      } else if (Array.isArray(newVal)) {
+        target[key] = union([], newVal, oldVal);
+      } else {
+        target[key] = cloneDeep(oldVal);
+      }
     }
   });
 


### PR DESCRIPTION
Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
More details and a better explanation can be found here:

- https://codeburst.io/what-is-prototype-pollution-49482fc4b638
- https://snyk.io/vuln/SNYK-JS-LODASH-450202
- https://snyk.io/vuln/SNYK-JS-ASSIGNDEEP-450211
